### PR TITLE
Fix graceful node shutdown for Ubuntu / Debian systems

### DIFF
--- a/playbooks/fix_graceful_node_shutdown.yml
+++ b/playbooks/fix_graceful_node_shutdown.yml
@@ -1,0 +1,13 @@
+# Context: https://github.com/kubernetes/kubernetes/issues/107043
+---
+
+- name: Gather facts
+  import_playbook: facts.yml
+
+- name: Enable kubelet systemd inhibitor
+  hosts: k8s_cluster
+  gather_facts: False
+  become: true
+  tasks:
+    - name: Copy kubelet systemd inhibitor file to be lexicographically last 
+      command: "cp /etc/systemd/logind.conf.d/99-kubelet.conf /etc/systemd/logind.conf.d/zz-99-kubelet.conf"


### PR DESCRIPTION
Ubuntu and other debian systems use `unattended-upgrades`.
This installs a shutdown inhibitor for systemd.
However, this inhibitor takes precedence over kubelet's inhibitor, and it has a rather small shutdown `InhibitDelayMaxSec`, 60s.
As a result, if you set a larger `shutdownGracePeriod`, it will be discarded and kubelet will not be able to start the shutdown manager. E.g.
```
> journalctl -u kubelet | grep "shutdown manager"
...
Jul 15 09:13:39 rpi01-ubuntupi kubelet[867]: I0715 09:13:39.282713     867 nodeshutdown_manager_linux.go:137] "Creating node shutdown manager" shutdownGracePeriodRequested="1m0s" shutdownGracePeriodCriticalPods="20s" shutdownGracePeriodByPodPriority=[{"Priority":0,"ShutdownGracePeriodSeconds":40},{"Priority":2000000000,"ShutdownGracePeriodSeconds":20}]
Jul 15 09:13:39 rpi01-ubuntupi kubelet[867]: E0715 09:13:39.523394     867 kubelet.go:1567] "Failed to start node shutdown manager" err="node shutdown manager was unable to update logind InhibitDelayMaxSec to 1m0s (ShutdownGracePeriod), current value of InhibitDelayMaxSec (30s) is less than requested ShutdownGracePeriod"
Jul 24 00:41:47 rpi01-ubuntupi kubelet[874]: I0724 00:41:47.047172     874 nodeshutdown_manager_linux.go:137] "Creating node shutdown manager" shutdownGracePeriodRequested="1m0s" shutdownGracePeriodCriticalPods="20s" shutdownGracePeriodByPodPriority=[{"Priority":0,"ShutdownGracePeriodSeconds":40},{"Priority":2000000000,"ShutdownGracePeriodSeconds":20}]
```
This adds a playbook that applies a sort of ugly but effective hack.

Source: https://github.com/kubernetes/kubernetes/issues/107043
